### PR TITLE
updated example to remove non-existent shorthand flags

### DIFF
--- a/cmd/gidari.go
+++ b/cmd/gidari.go
@@ -35,7 +35,7 @@ func main() {
 
 		Use:                    "gidari",
 		Short:                  "Persisted data from the web to your database",
-		Example:                "gidari -c config.yaml -v",
+		Example:                "gidari --config config.yaml",
 		BashCompletionFunction: bashCompletion,
 		Deprecated:             "",
 		Version:                version.Gidari,


### PR DESCRIPTION
Changed the example from `gidari -c config.yaml -v` to `gidari --config config.yaml` to remove non-existent shorthand. 

Resolves #173 

