### PR TITLE
add warning if no connectionStrings

### DIFF
--- a/cmd/gidari.go
+++ b/cmd/gidari.go
@@ -69,8 +69,6 @@ func run(configFilepath string, verboseLogging bool, _ []string) {
 		log.Fatalf("error creating config: %v", err)
 	}
 
-	cfg.Logger = logrus.New()
-
 	// If the user has not set the verbose flag, only log fatals.
 	if !verboseLogging {
 		cfg.Logger.SetLevel(logrus.FatalLevel)

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -305,7 +305,10 @@ func (cfg *Config) validate() error {
 	}
 
 	if cfg.ConnectionStrings == nil {
-		cfg.Logger.Warn("No connectionStrings specified in the config file.")
+		logWarn := tools.LogFormatter{
+			Msg: fmt.Sprintf("no connectionStrings specified in the config file"),
+		}
+		cfg.Logger.Warn(logWarn.String())
 	}
 
 	return nil

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -306,7 +306,7 @@ func (cfg *Config) validate() error {
 
 	if cfg.ConnectionStrings == nil {
 		logWarn := tools.LogFormatter{
-			Msg: fmt.Sprintf("no connectionStrings specified in the config file"),
+			Msg: "no connectionStrings specified in the config file",
 		}
 		cfg.Logger.Warn(logWarn.String())
 	}

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -191,6 +191,8 @@ type Config struct {
 func NewConfig(yamlBytes []byte) (*Config, error) {
 	var cfg Config
 
+	cfg.Logger = logrus.New()
+
 	if err := yaml.Unmarshal(yamlBytes, &cfg); err != nil {
 		return nil, fmt.Errorf("unable to unmarshal YAML: %w", err)
 	}
@@ -300,6 +302,10 @@ func (cfg *Config) validate() error {
 
 	if err := cfg.RateLimitConfig.validate(); err != nil {
 		return ErrInvalidRateLimit
+	}
+
+	if cfg.ConnectionStrings == nil {
+		cfg.Logger.Warn("No connectionStrings specified in the config file.")
 	}
 
 	return nil


### PR DESCRIPTION
Related to #190 

I add to move the logger creation to transport cause you can call it from validate().
Do you prefer an injection?