### PR TITLE
remove unreachable code

### DIFF
--- a/cmd/gidari.go
+++ b/cmd/gidari.go
@@ -52,7 +52,6 @@ func main() {
 
 	if err := cmd.Execute(); err != nil {
 		log.Fatal(err)
-		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
log.Fatal will call os.Exit(1).
So you don't need to call it yourself.