### PR TITLE
add host to logformat to support logging it in web worker logs

### DIFF
--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -453,6 +453,7 @@ func webWorker(ctx context.Context, workerID int, jobs <-chan *webJob) {
 			WorkerID:   workerID,
 			WorkerName: "web",
 			Duration:   time.Since(start),
+			Host:       rsp.Request.URL.Host,
 			Msg:        fmt.Sprintf("web request completed: %s", escapedPath),
 		}
 		job.logger.Infof(logInfo.String())

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -449,11 +449,14 @@ func webWorker(ctx context.Context, workerID int, jobs <-chan *webJob) {
 		escapedPath := strings.ReplaceAll(rsp.Request.URL.Path, "\n", "")
 		escapedPath = strings.ReplaceAll(escapedPath, "\r", "")
 
+		escapedHost := strings.ReplaceAll(rsp.Request.URL.Host, "\n", "")
+		escapedHost = strings.ReplaceAll(escapedHost, "\r", "")
+
 		logInfo := tools.LogFormatter{
 			WorkerID:   workerID,
 			WorkerName: "web",
 			Duration:   time.Since(start),
-			Host:       rsp.Request.URL.Host,
+			Host:       escapedHost,
 			Msg:        fmt.Sprintf("web request completed: %s", escapedPath),
 		}
 		job.logger.Infof(logInfo.String())

--- a/tools/log_formatter.go
+++ b/tools/log_formatter.go
@@ -18,6 +18,7 @@ type LogFormatter struct {
 	WorkerID      int
 	WorkerName    string
 	Duration      time.Duration
+	Host          string
 	Msg           string
 	UpsertedCount int64
 	MatchedCount  int64
@@ -32,6 +33,9 @@ const (
 
 	// LogFormatterDuration the label of the duration.
 	LogFormatterDuration = "d"
+
+	// LogFormatterHostName the label of the host name.
+	LogFormatterHostName = "host"
 
 	// LogFormatterMsg the label of the message.
 	LogFormatterMsg = "m"
@@ -57,6 +61,10 @@ func (lf LogFormatter) String() string {
 
 	if lf.Duration > 0 {
 		bldr.WriteString(fmt.Sprintf("%s:%s, ", LogFormatterDuration, lf.Duration))
+	}
+
+	if lf.Host != "" {
+		bldr.WriteString(fmt.Sprintf("%s:%s, ", LogFormatterHostName, lf.Host))
 	}
 
 	if lf.UpsertedCount > 0 {

--- a/tools/log_formatter_test.go
+++ b/tools/log_formatter_test.go
@@ -72,7 +72,10 @@ func TestLogFormatter(t *testing.T) {
 	})
 	t.Run("all", func(t *testing.T) {
 		t.Parallel()
-		lf := LogFormatter{WorkerID: 1, WorkerName: "worker", Duration: time.Second, Host: "localhost", Msg: "hello", UpsertedCount: 1}
+		lf := LogFormatter{
+			WorkerID: 1, WorkerName: "worker", Duration: time.Second, Host: "localhost",
+			Msg: "hello", UpsertedCount: 1,
+		}
 		if lf.String() != "{w:1, worker:worker, d:1s, host:localhost, u:1, m:hello}" {
 			t.Errorf("expected '{w:1, worker:worker, d:1s, host:localhost, u:1, m:hello}', got '%s'", lf.String())
 		}

--- a/tools/log_formatter_test.go
+++ b/tools/log_formatter_test.go
@@ -42,6 +42,13 @@ func TestLogFormatter(t *testing.T) {
 			t.Errorf("expected '{d:1s}', got '%s'", lf.String())
 		}
 	})
+	t.Run("host", func(t *testing.T) {
+		t.Parallel()
+		lf := LogFormatter{Host: "localhost:8080"}
+		if lf.String() != "{host:localhost:8080}" {
+			t.Errorf("expected '{host:localhost:8080}', got '%s'", lf.String())
+		}
+	})
 	t.Run("msg", func(t *testing.T) {
 		t.Parallel()
 		lf := LogFormatter{Msg: "hello"}

--- a/tools/log_formatter_test.go
+++ b/tools/log_formatter_test.go
@@ -72,9 +72,9 @@ func TestLogFormatter(t *testing.T) {
 	})
 	t.Run("all", func(t *testing.T) {
 		t.Parallel()
-		lf := LogFormatter{WorkerID: 1, WorkerName: "worker", Duration: time.Second, Msg: "hello", UpsertedCount: 1}
-		if lf.String() != "{w:1, worker:worker, d:1s, u:1, m:hello}" {
-			t.Errorf("expected '{w:1, worker:worker, d:1s, u:1, m:hello}', got '%s'", lf.String())
+		lf := LogFormatter{WorkerID: 1, WorkerName: "worker", Duration: time.Second, Host: "localhost", Msg: "hello", UpsertedCount: 1}
+		if lf.String() != "{w:1, worker:worker, d:1s, host:localhost, u:1, m:hello}" {
+			t.Errorf("expected '{w:1, worker:worker, d:1s, host:localhost, u:1, m:hello}', got '%s'", lf.String())
 		}
 	})
 }


### PR DESCRIPTION
Add URL host to the transport web worker logs #165

Modified the tools.LogFormatter to incorporate & log hostname of request
