### PR TITLE
Fixes #164 Wait for all mongodb instances to go up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - mongo_network
     volumes:
       - ./.db/mongo1:/data/db
+      - ./scripts/wait-for-mongodb.sh:/scripts/wait-for-mongodb.sh
       - ./scripts/rs-init.sh:/scripts/rs-init.sh
     links:
       - mongo2

--- a/scripts/build-storage.sh
+++ b/scripts/build-storage.sh
@@ -26,8 +26,8 @@ docker-compose -f "docker-compose.yml" up -d \
 	--force-recreate \
 	--build mongo3
 
-echo "Waiting for MongoDB to start..."
-sleep 5
+echo -n "Waiting for MongoDB to start..."
+docker-compose -f "docker-compose.yml" exec -T mongo1 /scripts/wait-for-mongodb.sh
 
 echo "Creating replica set..."
 docker-compose -f "docker-compose.yml" exec -T mongo1 /scripts/rs-init.sh

--- a/scripts/wait-for-mongodb.sh
+++ b/scripts/wait-for-mongodb.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+CHECK_CMD="mongosh --eval 'db.runCommand(\"ping\").ok' --quiet --host"
+
+while [ -z `$CHECK_CMD mongo1 2>/dev/null` ] || \
+      [ -z `$CHECK_CMD mongo2 2>/dev/null` ] || \
+      [ -z `$CHECK_CMD mongo3 2>/dev/null` ]
+do
+    echo -n "."
+    sleep 1
+done
+
+echo ""


### PR DESCRIPTION
This PR adds a script that will wait for all mongodb instances to be up before continuing