### PR TITLE
Dockerize gofumpt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ lint:
 # fmt runs the formatter.
 .PHONY: fmt
 fmt:
-	gofumpt -l -w .
+	docker build -t gofumpt -f scripts/fmt.Dockerfile .
+	docker run -t -v $(PWD):/app gofumpt 
 	golangci-lint run --fix
 
 # add-license adds the license to all the top of all the .go files.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,13 @@ services:
     networks:
       - mongo_network
       - postgres_network
+    
+  fmt:
+    build:
+      context: .
+      dockerfile: scripts/fmt.Dockerfile
+    volumes:
+      - .:/app
 
   mongo1:
     hostname: mongo1

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -7,7 +7,7 @@
   - [Running Integration Tests](#running-integration-tests)
 - [Socials](#socials)
 
-Thank you for your intest in contributing to Gidari! Please make sure to fork this repository before working through issues.
+Thank you for your interest in contributing to Gidari! Please make sure to fork this repository before working through issues.
 
 ## Bug Fixes and New Features
 
@@ -28,7 +28,6 @@ To develop locally you need to install the following dependencies:
 3. protobuf: http://google.github.io/proto-lens/installing-protoc.html
 4. protoc-gen-go: https://developers.google.com/protocol-buffers/docs/gotutorial#compiling-your-protocol-buffers
 5. golangci-lint (test only): https://golangci-lint.run/usage/install/#local-installation
-6. gofumt (test only): https://github.com/mvdan/gofumpt
 
 ## Build
 

--- a/scripts/fmt.Dockerfile
+++ b/scripts/fmt.Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.19-alpine
+
+# Create the working directory.
+WORKDIR /app
+
+# Install gofumpt
+RUN go install mvdan.cc/gofumpt@latest
+
+# Run gofumpt
+CMD ["gofumpt", "-l", "-w", "."]


### PR DESCRIPTION
### Fixes - #224 

### Manual Test

I intentionally added a new line at the function start to test if the `make fmt` or docker-compose run still fixes it.

```sh
func TestTimeseries(t *testing.T) {

	t.Parallel()
	t.Run("chunks where end date is before last iteration", func(t *testing.T) {
		t.Parallel()
```

Test with docker-compose:

```sh
gidari on main [!?] via 🐹 v1.18.4 on 🐳 v20.10.17 at ☸️  microk8s
➜ docker-compose up -d fmt
[+] Building 0.1s (7/7) FINISHED
 => [internal] load build definition from fmt.Dockerfile                                                                                                                                              0.0s
 => => transferring dockerfile: 36B                                                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                                                     0.0s
 => => transferring context: 34B                                                                                                                                                                      0.0s
 => [internal] load metadata for docker.io/library/golang:1.19-alpine                                                                                                                                 0.0s
 => [1/3] FROM docker.io/library/golang:1.19-alpine                                                                                                                                                   0.0s
 => CACHED [2/3] WORKDIR /app                                                                                                                                                                         0.0s
 => CACHED [3/3] RUN go install mvdan.cc/gofumpt@latest                                                                                                                                               0.0s
 => exporting to image                                                                                                                                                                                0.0s
 => => exporting layers                                                                                                                                                                               0.0s
 => => writing image sha256:2deccab2d68769b0ae774aeedfc4a6fc9905f3664d6ec2bee66893244a9783fb                                                                                                          0.0s
 => => naming to docker.io/library/gidari-fmt                                                                                                                                                         0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
[+] Running 1/1
 ⠿ Container gidari-fmt-1  Started                                                                                                                                                                    0.3s

gidari on main [!?] via 🐹 v1.18.4 on 🐳 v20.10.17 at ☸️  microk8s
➜ docker ps -a
CONTAINER ID   IMAGE        COMMAND             CREATED         STATUS                     PORTS     NAMES
8c2453da51a2   gidari-fmt   "gofumpt -l -w ."   5 seconds ago   Exited (0) 5 seconds ago             gidari-fmt-1

gidari on main [!?] via 🐹 v1.18.4 on 🐳 v20.10.17 at ☸️  microk8s
➜ docker logs 8c2453da51a2
internal/transport/transport_test.go
```

Test with `make fmt`
```sh
gidari on main [!?] via 🐹 v1.18.4 on 🐳 v20.10.17 at ☸️  microk8s
➜ make fmt
docker build -t gofumpt -f scripts/fmt.Dockerfile .
[+] Building 0.1s (7/7) FINISHED
 => [internal] load build definition from fmt.Dockerfile                                                                                                                                                0.0s
 => => transferring dockerfile: 41B                                                                                                                                                                     0.0s
 => [internal] load .dockerignore                                                                                                                                                                       0.0s
 => => transferring context: 34B                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/golang:1.19-alpine                                                                                                                                   0.0s
 => [1/3] FROM docker.io/library/golang:1.19-alpine                                                                                                                                                     0.0s
 => CACHED [2/3] WORKDIR /app                                                                                                                                                                           0.0s
 => CACHED [3/3] RUN go install mvdan.cc/gofumpt@latest                                                                                                                                                 0.0s
 => exporting to image                                                                                                                                                                                  0.0s
 => => exporting layers                                                                                                                                                                                 0.0s
 => => writing image sha256:2deccab2d68769b0ae774aeedfc4a6fc9905f3664d6ec2bee66893244a9783fb                                                                                                            0.0s
 => => naming to docker.io/library/gofumpt                                                                                                                                                              0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
docker run -t -v /Users/gaurav.gahlot/go/src/github.com/gauravgahlot/gidari:/app gofumpt
internal/transport/transport_test.go
golangci-lint run --fix
WARN [linters context] contextcheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649.
```